### PR TITLE
Missing azuread_authentication_only_enabled attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ Description: - `login_username` - (Required) The login name of the principal to 
 - `object_id` - (Required) The Object ID of the principal to set as the Managed Instance Administrator.
 - `principal_type` - (Required) The type of the principal. Possible values are `Application`, `Group`, and `User`.
 - `tenant_id` - (Required) The Azure Active Directory Tenant ID.
+- `azuread_authentication_only_enabled` - (Optional) Whether Azure AD authentication only is enabled for the Managed Instance Administrator.
 
 Type:
 
 ```hcl
 object({
-    login_username = optional(string)
-    object_id      = optional(string)
-    principal_type = optional(string)
-    tenant_id      = optional(string)
+    login_username                      = optional(string)
+    object_id                           = optional(string)
+    principal_type                      = optional(string)
+    azuread_authentication_only_enabled = optional(bool)
+    tenant_id                           = optional(string)
   })
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,11 @@ resource "azurerm_mssql_managed_instance" "this" {
     for_each = try(var.active_directory_administrator.object_id, null) != null ? [var.active_directory_administrator] : []
 
     content {
-      login_username = azure_active_directory_administrator.value.login_username
-      object_id      = azure_active_directory_administrator.value.object_id
-      principal_type = azure_active_directory_administrator.value.principal_type
-      tenant_id      = azure_active_directory_administrator.value.tenant_id
+      login_username                      = azure_active_directory_administrator.value.login_username
+      object_id                           = azure_active_directory_administrator.value.object_id
+      principal_type                      = azure_active_directory_administrator.value.principal_type
+      azuread_authentication_only_enabled = azure_active_directory_administrator.value.azuread_authentication_only_enabled
+      tenant_id                           = azure_active_directory_administrator.value.tenant_id
     }
   }
   dynamic "timeouts" {

--- a/variables.instance.tf
+++ b/variables.instance.tf
@@ -43,10 +43,11 @@ variable "vcores" {
 
 variable "active_directory_administrator" {
   type = object({
-    login_username = optional(string)
-    object_id      = optional(string)
-    principal_type = optional(string)
-    tenant_id      = optional(string)
+    login_username                      = optional(string)
+    object_id                           = optional(string)
+    principal_type                      = optional(string)
+    azuread_authentication_only_enabled = optional(bool)
+    tenant_id                           = optional(string)
   })
   default     = {}
   description = <<-DESCRIPTION
@@ -54,6 +55,7 @@ variable "active_directory_administrator" {
  - `object_id` - (Required) The Object ID of the principal to set as the Managed Instance Administrator.
  - `principal_type` - (Required) The type of the principal. Possible values are `Application`, `Group`, and `User`.
  - `tenant_id` - (Required) The Azure Active Directory Tenant ID.
+ - `azuread_authentication_only_enabled` - (Optional) Whether Azure AD authentication only is enabled for the Managed Instance Administrator.
 DESCRIPTION
   nullable    = false
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes NA
Closes NA
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [X] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

https://github.com/Azure/terraform-azurerm-avm-res-sql-managedinstance/actions/runs/22871493010

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
