### PR TITLE
fix : Added resource azapi_resource_action identity_read (method = GE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The following resources are used by this module:
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azapi_resource.identity](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
-- [azurerm_resource_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_resource_action.identity_read](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.mssql_managed_instance_security_alert_policy](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.mssql_managed_instance_vulnerability_assessment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.sql_advanced_threat_protection](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
@@ -846,7 +847,7 @@ Description: The internal format of instance databases reflecting the SQL engine
 
 ### <a name="output_identity"></a> [identity](#output\_identity)
 
-Description: Managed identities for the SQL MI instance.  This is not available from the `resource` output because AzureRM doesn't yet support adding both User and System Assigned identities.
+Description: Managed identities for the SQL MI instance.  This is not available from the `resource` output because AzureRM doesn't yet support adding both User and System Assigned identities. Sourced from a stateful AzAPI GET so the value is known at plan time on subsequent applies, preventing constant destroy/create churn for downstream resources (e.g. role assignments) that depend on `principal_id`.
 
 ### <a name="output_is_general_purpose_v2"></a> [is\_general\_purpose\_v2](#output\_is\_general\_purpose\_v2)
 

--- a/main.tf
+++ b/main.tf
@@ -246,8 +246,8 @@ resource "azapi_resource_action" "sql_managed_instance_patch_identities" {
 # `azapi_resource_action.sql_managed_instance_patch_identities`. This must remain a data source
 # (and cannot depend on the PATCH action) to avoid a cycle: the PATCH body consumes this value.
 data "azapi_resource" "identity" {
-  type                   = "Microsoft.Sql/managedInstances@2025-02-01-preview"
   resource_id            = azurerm_mssql_managed_instance.this.id
+  type                   = "Microsoft.Sql/managedInstances@2025-02-01-preview"
   response_export_values = ["properties.servicePrincipal"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -252,6 +252,34 @@ data "azapi_resource" "identity" {
   response_export_values = ["identity", "properties"]
 }
 
+# Performs a stateful GET of the managed instance after the identity PATCH (and ATP) actions
+# have run, persisting `identity` and `properties` in Terraform state.
+#
+# Module outputs (e.g. `identity`, `database_format`) reference this resource instead of the
+# `data.azapi_resource.identity` data source above. Data source values are re-read every apply
+# and therefore unknown at plan time, which causes downstream consumers (such as a
+# `Key Vault Crypto Service Encryption User` role assignment for TDE that uses the system
+# assigned identity's `principal_id`) to be planned for destroy + create on every run.
+# See: https://github.com/Azure/terraform-azurerm-avm-res-sql-managedinstance/issues
+resource "azapi_resource_action" "identity_read" {
+  method                 = "GET"
+  resource_id            = azurerm_mssql_managed_instance.this.id
+  type                   = "Microsoft.Sql/managedInstances@2025-02-01-preview"
+  response_export_values = ["identity", "properties"]
+
+  depends_on = [
+    azapi_resource_action.sql_managed_instance_patch_identities,
+  ]
+
+  # Re-fetch only when the identity-affecting patch action changes, keeping the cached
+  # identity/properties stable across runs so plan-time references remain known.
+  lifecycle {
+    replace_triggered_by = [
+      azapi_resource_action.sql_managed_instance_patch_identities,
+    ]
+  }
+}
+
 resource "azapi_resource_action" "sql_advanced_threat_protection" {
   method      = "PUT"
   resource_id = "${azurerm_mssql_managed_instance.this.id}/advancedThreatProtectionSettings/Default"

--- a/main.tf
+++ b/main.tf
@@ -241,26 +241,23 @@ resource "azapi_resource_action" "sql_managed_instance_patch_identities" {
   ]
 }
 
-data "azurerm_resource_group" "parent" {
-  name = azurerm_mssql_managed_instance.this.resource_group_name
-}
-
+# Pre-PATCH read of the managed instance, used solely by `local.current_service_principal_enabled`
+# to detect an existing SystemAssigned service principal so it can be preserved in the body of
+# `azapi_resource_action.sql_managed_instance_patch_identities`. This must remain a data source
+# (and cannot depend on the PATCH action) to avoid a cycle: the PATCH body consumes this value.
 data "azapi_resource" "identity" {
-  name                   = azurerm_mssql_managed_instance.this.name
-  parent_id              = data.azurerm_resource_group.parent.id
   type                   = "Microsoft.Sql/managedInstances@2025-02-01-preview"
-  response_export_values = ["identity", "properties"]
+  resource_id            = azurerm_mssql_managed_instance.this.id
+  response_export_values = ["properties.servicePrincipal"]
 }
 
-# Performs a stateful GET of the managed instance after the identity PATCH (and ATP) actions
-# have run, persisting `identity` and `properties` in Terraform state.
-#
-# Module outputs (e.g. `identity`, `database_format`) reference this resource instead of the
-# `data.azapi_resource.identity` data source above. Data source values are re-read every apply
-# and therefore unknown at plan time, which causes downstream consumers (such as a
-# `Key Vault Crypto Service Encryption User` role assignment for TDE that uses the system
-# assigned identity's `principal_id`) to be planned for destroy + create on every run.
-# See: https://github.com/Azure/terraform-azurerm-avm-res-sql-managedinstance/issues
+# Stateful GET of the managed instance after the identity PATCH action runs. The captured
+# `identity` and `properties` are persisted in Terraform state and are therefore known at
+# plan time on subsequent runs. Module outputs (e.g. `identity`, `database_format`) read
+# from this resource rather than the data source above so that downstream consumers — such
+# as a `Key Vault Crypto Service Encryption User` role assignment for TDE that depends on
+# the system assigned identity's `principal_id` — are not planned for destroy + create on
+# every apply. `replace_triggered_by` re-fetches only when the PATCH action changes.
 resource "azapi_resource_action" "identity_read" {
   method                 = "GET"
   resource_id            = azurerm_mssql_managed_instance.this.id
@@ -271,8 +268,6 @@ resource "azapi_resource_action" "identity_read" {
     azapi_resource_action.sql_managed_instance_patch_identities,
   ]
 
-  # Re-fetch only when the identity-affecting patch action changes, keeping the cached
-  # identity/properties stable across runs so plan-time references remain known.
   lifecycle {
     replace_triggered_by = [
       azapi_resource_action.sql_managed_instance_patch_identities,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,26 +1,26 @@
 output "database_format" {
   description = "The internal format of instance databases reflecting the SQL engine version (update policy). Possible values are 'AlwaysUpToDate', 'SQLServer2022', or 'SQLServer2025'."
-  value       = try(data.azapi_resource.identity.output.properties.databaseFormat, null)
+  value       = try(azapi_resource_action.identity_read.output.properties.databaseFormat, null)
 }
 
 output "identity" {
-  description = "Managed identities for the SQL MI instance.  This is not available from the `resource` output because AzureRM doesn't yet support adding both User and System Assigned identities."
-  value       = try(data.azapi_resource.identity.output.identity, null)
+  description = "Managed identities for the SQL MI instance.  This is not available from the `resource` output because AzureRM doesn't yet support adding both User and System Assigned identities. Sourced from a stateful AzAPI GET so the value is known at plan time on subsequent applies, preventing constant destroy/create churn for downstream resources (e.g. role assignments) that depend on `principal_id`."
+  value       = try(azapi_resource_action.identity_read.output.identity, null)
 }
 
 output "is_general_purpose_v2" {
   description = "Whether the SQL Managed Instance is using the Next-gen General Purpose (GPv2) service tier."
-  value       = try(data.azapi_resource.identity.output.properties.isGeneralPurposeV2, false)
+  value       = try(azapi_resource_action.identity_read.output.properties.isGeneralPurposeV2, false)
 }
 
 output "memory_size_in_gb" {
   description = "The actual memory size in GB allocated to the SQL Managed Instance."
-  value       = try(data.azapi_resource.identity.output.properties.memorySizeInGB, null)
+  value       = try(azapi_resource_action.identity_read.output.properties.memorySizeInGB, null)
 }
 
 output "pricing_model" {
   description = "The pricing model of the SQL Managed Instance. Possible values are 'Regular' or 'Freemium'."
-  value       = try(data.azapi_resource.identity.output.properties.pricingModel, null)
+  value       = try(azapi_resource_action.identity_read.output.properties.pricingModel, null)
 }
 
 output "private_endpoints" {
@@ -44,10 +44,10 @@ output "resource_id" {
 
 output "service_principal" {
   description = "The system-assigned service principal details for the SQL Managed Instance. Required for Windows Authentication with Microsoft Entra ID."
-  value       = try(data.azapi_resource.identity.output.properties.servicePrincipal, null)
+  value       = try(azapi_resource_action.identity_read.output.properties.servicePrincipal, null)
 }
 
 output "storage_iops" {
   description = "The actual storage IOPS allocated to the SQL Managed Instance."
-  value       = try(data.azapi_resource.identity.output.properties.storageIOps, null)
+  value       = try(azapi_resource_action.identity_read.output.properties.storageIOps, null)
 }


### PR DESCRIPTION
## Description

Fixes #79

The module's stateful outputs (`identity`, `database_format`, `is_general_purpose_v2`, `memory_size_in_gb`, `pricing_model`, `service_principal`, `storage_iops`) were sourced from the `data.azapi_resource.identity` data source. Because data sources are re-read on every apply, their values are unknown at plan time. Downstream consumers that reference `module.sql_mi.identity[...].principal_id` (for example a `Key Vault Crypto Service Encryption User` role assignment used for TDE with a customer-managed key) therefore showed a destroy + create churn on every `terraform plan` / `apply`, even when nothing had actually changed.

### Changes

- **`main.tf`**: Added a new `azapi_resource_action.identity_read` resource that performs a stateful `GET` against `Microsoft.Sql/managedInstances@2025-02-01-preview` and persists `identity` and `properties` in Terraform state.
  - Runs after `azapi_resource_action.sql_managed_instance_patch_identities` via `depends_on`.
  - Uses `lifecycle.replace_triggered_by` on the identity PATCH action so the cached values are only refreshed when identities actually change, keeping plan-time references stable across runs.
- **`outputs.tf`**: Switched the following outputs from `data.azapi_resource.identity` to `azapi_resource_action.identity_read`:
  - `identity`
  - `database_format`
  - `is_general_purpose_v2`
  - `memory_size_in_gb`
  - `pricing_model`
  - `service_principal`
  - `storage_iops`
- **`outputs.tf` / `README.md`**: Expanded the `identity` output description to document that the value is now sourced from a stateful AzAPI GET and is known at plan time, preventing destroy/create churn for downstream role assignments that depend on `principal_id`.
- **`README.md`**: Regenerated to include the new `azapi_resource_action.identity_read` resource entry.

### Impact

- No breaking change — output names, types, and shapes are unchanged.
- Downstream resources referencing `module.<name>.identity[...].principal_id` will be stable across plans/applies after the first apply on this version.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
